### PR TITLE
fix(auth): correct for various capitals in Headers from ShipStation

### DIFF
--- a/app/code/community/Auctane/Api/Model/Server/Adapter.php
+++ b/app/code/community/Auctane/Api/Model/Server/Adapter.php
@@ -76,9 +76,11 @@ class Auctane_Api_Model_Server_Adapter
         // Shipstation started sending a token to the endpoint, which is an update to how m2 adapter works
         // teh value of Shipstation-Access-Token is what used to be in HTTP_SS_AUTH_PW
         $headers = getallheaders();
-        if(isset($headers['Shipstation-Access-Token'])) {
+        if(
+			isset($headers['Shipstation-Access-Token']) || isset($headers['ShipStation-Access-Token'])
+		) {
             $_SERVER['HTTP_SS_AUTH_USER'] = 'shipstation';
-            $_SERVER['HTTP_SS_AUTH_PW'] = $headers['Shipstation-Access-Token'];
+            $_SERVER['HTTP_SS_AUTH_PW'] = $headers['Shipstation-Access-Token'] ?: $headers['ShipStation-Access-Token'];
         }
 
 


### PR DESCRIPTION
Requests from Shipstation allow for a non-standard header capitalization policy.

Currently, requests go out with either `Shipstation-Access-Token` as the header or `ShipStation-Access-Token`. This PR addresses that concern.